### PR TITLE
Enable built-in WiFi, install brcmfmac43430 firmware

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -127,6 +127,11 @@ apt-get upgrade -y
 #   firmware-ralink \
 #   firmware-realtek
 
+# install WiFi firmware for internal RPi3 WiFi module
+mkdir -p /lib/firmware/brcm
+curl -sSL https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.bin > /lib/firmware/brcm/brcmfmac43430-sdio.bin
+curl -sSL https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.txt > /lib/firmware/brcm/brcmfmac43430-sdio.txt
+
 # install kernel- and firmware-packages
 # apt-get install -y \
 #   "raspberrypi-kernel=${KERNEL_BUILD}" \

--- a/builder/test-integration/spec/hypriotos-image/base/rpi3_wifi_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/rpi3_wifi_spec.rb
@@ -14,3 +14,29 @@ if cpu_info.include?('a02082') or cpu_info.include?('a22082')
     end
   end
 end
+
+describe "RPi 3: built-in wifi firmware is installed" do
+  describe file('/lib/firmware/brcm/brcmfmac43430-sdio.bin') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+  end
+
+  describe file('/lib/firmware/brcm/brcmfmac43430-sdio.txt') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+  end
+end
+
+describe "RPi 3: built-in wifi works" do
+  describe command('ifconfig -a') do
+    its(:stdout) { should contain /wlan0/ }
+  end
+
+  describe command('ethtool -i wlan0') do
+    its(:stdout) { should contain /driver: brcmfmac/ }
+    its(:stdout) { should contain /version: 7.45.41.26/ }
+    its(:stdout) { should contain /firmware-version: 01-df77e4a7/ }
+  end
+end


### PR DESCRIPTION
To activate WiFi you have to run `device-init` with the command `sudo device-init wifi set -s <ssid> -p <password> -i wlan0` and WiFi starts immediately.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>