### PR TITLE
Fix versioning of os-rootfs

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -279,7 +279,7 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 #TODO:+++ remove as soon as we do have a Debian Stretch os-rootfs image
 # set HypriotOS version infos
 BUILD_ARCH="${BUILD_ARCH:-arm64}"
-HYPRIOT_OS_VERSION="${HYPRIOT_OS_VERSION:-v1.1.1}"
+HYPRIOT_OS_VERSION="${HYPRIOT_OS_VERSION:-v1.2.3}"
 echo "HYPRIOT_OS=\"HypriotOS/${BUILD_ARCH}\"" >> /etc/os-release
 echo "HYPRIOT_OS_VERSION=\"${HYPRIOT_OS_VERSION}\"" >> /etc/os-release
 #TODO:---

--- a/builder/files/boot/user-data
+++ b/builder/files/boot/user-data
@@ -41,6 +41,7 @@ package_upgrade: false
 #  - ntp
 
 # # WiFi connect to HotSpot
+# # - use `wpa_passphrase SSID PASSWORD` to encrypt the psk
 # write_files:
 #   - content: |
 #       allow-hotplug wlan0

--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -7,7 +7,7 @@ describe file('/etc/os-release') do
   it { should be_owned_by 'root' }
   its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/arm64"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v1.1.1"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v1.2.3"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi 3 64bit"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end
@@ -17,7 +17,7 @@ describe file('/boot/os-release') do
   it { should be_owned_by 'root' }
   its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/arm64"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v1.1.1"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v1.2.3"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi 3 64bit"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end


### PR DESCRIPTION
- Fix setting of HYPRIOT_OS_VERSION to v1.2.3 (from os-rootfs)
- Add cloud-init hints for encrypting WiFi password

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>