### PR TITLE
Enable shellcheck and test for Travis builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION ?= dirty
+
 default: build
 
 build:
@@ -10,10 +12,10 @@ shell: build
 	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64 bash
 
 test:
-	VERSION=dirty docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-dirty.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
+	docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
 
 shellcheck: build
-	VERSION=dirty docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi64 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
+	docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi64 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
 
 vagrant:
 	vagrant up

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@ VERSION ?= dirty
 default: build
 
 build:
-	docker build -t image-builder-rpi64 .
+	VERSION=${VERSION} docker build -t image-builder-rpi64 .
 
 sd-image: build
-	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64
+	VERSION=${VERSION} docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64
 
 shell: build
-	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64 bash
+	VERSION=${VERSION} docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64 bash
 
 test:
-	docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
+	VERSION=${VERSION} docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
 
 shellcheck: build
-	docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi64 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
+	VERSION=${VERSION} docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi64 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
 
 vagrant:
 	vagrant up

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -218,7 +218,7 @@ curl -sSL "https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VE
 
 # install Docker Compose via pip
 curl -sSL https://bootstrap.pypa.io/get-pip.py | python
-pip install docker-compose==${DOCKER_COMPOSE_VERSION}
+pip install docker-compose=="${DOCKER_COMPOSE_VERSION}"
 
 # install bash completion for Docker Compose
 curl -sSL "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
@@ -278,13 +278,14 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 #TODO:+++ remove as soon as we do have a Debian Stretch os-rootfs image
 # set HypriotOS version infos
+#TODO:---
+# set device label and version number
 BUILD_ARCH="${BUILD_ARCH:-arm64}"
 HYPRIOT_OS_VERSION="${HYPRIOT_OS_VERSION:-v1.2.3}"
-echo "HYPRIOT_OS=\"HypriotOS/${BUILD_ARCH}\"" >> /etc/os-release
-echo "HYPRIOT_OS_VERSION=\"${HYPRIOT_OS_VERSION}\"" >> /etc/os-release
-#TODO:---
-
-# set device label and version number
-echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
-echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
+cat <<EOF >> /etc/os-release
+HYPRIOT_OS="HypriotOS/${BUILD_ARCH}"
+HYPRIOT_OS_VERSION="${HYPRIOT_OS_VERSION}"
+HYPRIOT_DEVICE="$HYPRIOT_DEVICE"
+HYPRIOT_IMAGE_VERSION="$HYPRIOT_IMAGE_VERSION"
+EOF
 cp /etc/os-release /boot/os-release

--- a/builder/test/image_spec.rb
+++ b/builder/test/image_spec.rb
@@ -26,7 +26,7 @@ describe "SD card image" do
   context "Binary dpkg" do
     let(:stdout) { run_mounted("file-architecture /usr/bin/dpkg").stdout }
 
-    it "is compiled for ARM architecture" do
+    it "is compiled for ARM aarch64 architecture" do
       expect(stdout).to contain('aarch64')
     end
   end
@@ -43,11 +43,11 @@ describe "SD card image" do
     end
   end
 
-  context "Docker service file" do
-    let(:stdout) { run_mounted("cat /etc/systemd/system/docker.service.d/overlay.conf").stdout }
+  context "Docker systemd service file" do
+    let(:stdout) { run_mounted("cat /lib/systemd/system/docker.service").stdout }
 
-    it "Daemon uses overlay storage driver" do
-      expect(stdout).to contain("--storage-driver overlay")
+    it "Docker Engine is installed" do
+      expect(stdout).to contain("/usr/bin/dockerd")
     end
   end
 end

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -29,7 +29,7 @@ echo "BUILD_NR=$BUILD_NR"
 BUILD_DEST=builds/$BUILD_NR
 mkdir -p $BUILD_DEST
 #-build
-make shellcheck
+VERSION=v$BUILD_NR make shellcheck
 VERSION=v$BUILD_NR make sd-image
 #-test
 VERSION=v$BUILD_NR make test

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -29,8 +29,10 @@ echo "BUILD_NR=$BUILD_NR"
 BUILD_DEST=builds/$BUILD_NR
 mkdir -p $BUILD_DEST
 #-build
-###make shellcheck
+make shellcheck
 VERSION=v$BUILD_NR make sd-image
+#-test
+VERSION=v$BUILD_NR make test
 #-move artifacts to build dest
 mv hypriotos-rpi64* $BUILD_DEST/
 


### PR DESCRIPTION
- Fix test if Docker Engine is installed
- Fix shellcheck testing
- Enable shellcheck and test for Travis builds

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>