### PR TITLE
Unquoting psk from wpa_supplicant.conf

### DIFF
--- a/builder/files/boot/user-data
+++ b/builder/files/boot/user-data
@@ -54,7 +54,7 @@ package_upgrade: false
 #       update_config=1
 #       network={
 #       ssid="YOUR_WIFI_SSID"
-#       psk="YOUR_WIFI_PASSWORD"
+#       psk=YOUR_WIFI_PASSWORD
 #       proto=RSN
 #       key_mgmt=WPA-PSK
 #       pairwise=CCMP


### PR DESCRIPTION
Quoting your encrypted password can actually fail to parse when key length is large.