### PR TITLE
change /boot/cmdline.txt for newer kernels

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -144,7 +144,7 @@ curl -sSL https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/br
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 
 # boot/cmdline.txt
-echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 net.ifnames=0" > /boot/cmdline.txt
+echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 net.ifnames=0" > /boot/cmdline.txt
 # " net.ifnames=0" is neccessary for Debian Stretch: see https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
 
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)


### PR DESCRIPTION
There seemed to be a problem running newer 4.9.x kernels while kgdboc instruction was set in /boot/cmdline.txt