### PR TITLE
Add dependencies for cloud-init

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -200,9 +200,11 @@ apt-get install -y \
 apt-get install -y \
   lsb-release
 
-# install cloud-init
+# install cloud-init and its required dependencies
 apt-get install -y \
-  cloud-init
+  cloud-init \
+  dirmngr \
+  less
 
 mkdir -p /var/lib/cloud/seed/nocloud-net
 ln -s /boot/user-data /var/lib/cloud/seed/nocloud-net/user-data


### PR DESCRIPTION
- Packages `dirmngr` and `less` are required for some use cases

Fixes #56 and https://github.com/hypriot/os-rootfs/issues/64

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>
  