### PR TITLE
Resize root partition for kernel 4.14

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -177,6 +177,10 @@ proc /proc proc defaults 0 0
 /dev/mmcblk0p2 / ext4 defaults,noatime 0 1
 " > /etc/fstab
 
+# run resize script on first boot (phase 1)
+mv /sbin/init /sbin/init.bak
+ln -s /sbin/resizefs /sbin/init
+
 # as the Pi does not have a hardware clock we need a fake one
 apt-get install -y \
   fake-hwclock

--- a/builder/files/etc/firstboot.d/10-resize-rootdisk
+++ b/builder/files/etc/firstboot.d/10-resize-rootdisk
@@ -1,53 +1,12 @@
 #!/bin/bash
 set -ex
 
+# resize script phase 2
+
 if ! [ -h /dev/disk/by-label/root ]; then
   echo "/dev/disk/by-label/root does not exist or is not a symlink. Don't know how to expand"
   return 0
 fi
 
 ROOT_PART=$(readlink /dev/disk/by-label/root)
-PART_NUM=${ROOT_PART#../../mmcblk0p}
-if [ "$PART_NUM" = "$ROOT_PART" ]; then
-  echo "/dev/disk/by-label/root is not an SD card. Don't know how to expand"
-  return 0
-fi
-
-# NOTE: the NOOBS partition layout confuses parted. For now, let's only
-# agree to work with a sufficiently simple partition layout
-if [ "$PART_NUM" -ne 2 ]; then
-  echo "Your partition layout is not currently supported by this tool. You are probably using NOOBS, in which case your root filesystem is already expanded anyway."
-  return 0
-fi
-
-LAST_PART_NUM=$(parted /dev/mmcblk0 -ms unit s p | tail -n 1 | cut -f 1 -d:)
-
-if [ "$LAST_PART_NUM" != "$PART_NUM" ]; then
-  echo "/dev/disk/by-label/root is not the last partition. Don't know how to expand"
-  return 0
-fi
-
-# Get the starting offset of the root partition
-PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d:)
-# remove trailing 's'
-PART_START=${PART_START::-1}
-[ "$PART_START" ] || return 1
-# Return value will likely be error for fdisk as it fails to reload the
-# partition table because the root fs is mounted
-set +e
-fdisk /dev/mmcblk0 <<EOF
-p
-d
-$PART_NUM
-n
-p
-$PART_NUM
-$PART_START
-
-p
-w
-EOF
-set -e
-
-partprobe
-/sbin/resize2fs /dev/disk/by-label/root
+/sbin/resize2fs $ROOT_PART

--- a/builder/files/sbin/resizefs
+++ b/builder/files/sbin/resizefs
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mount -t tmpfs tmp /run
+mount / -o remount,rw
+
+PART_START=$(cat /sys/block/mmcblk0/mmcblk0p2/start)
+
+echo "Modifying partition table"
+fdisk -u /dev/mmcblk0 <<EOF
+p
+d
+2
+n
+p
+2
+$PART_START
+
+p
+w
+EOF
+echo "Partition table changed. rebooting"
+rm /sbin/init /sbin/resizefs
+mv /sbin/init.bak /sbin/init
+echo 1 > /proc/sys/kernel/sysrq
+mount / -o remount,ro
+sync
+echo b > /proc/sysrq-trigger


### PR DESCRIPTION
**Not tested!**

The code is similar to the method I've done in a private Rpi3b+ Linux Alpine image. 
Follow up to: Issue https://github.com/DieterReuter/image-builder-rpi64/issues/89 where partitions are no longer resized properly.