### PR TITLE
Syntax Fix to Enable Cgroups for Memory

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -145,7 +145,7 @@ apt-get upgrade -y
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 
 # boot/cmdline.txt
-echo "dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_memory=1 swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 net.ifnames=0" > /boot/cmdline.txt
+echo "dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 net.ifnames=0" > /boot/cmdline.txt
 # " net.ifnames=0" is neccessary for Debian Stretch: see https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
 
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)


### PR DESCRIPTION
I guess in more recent kernel versions, they fixed the syntax discrepancy when enabling cgroups for memory.

When I tried installing kubernetes with kubeadm, I got the following error with the "cgroup_memory=1" syntax:
```
[ERROR SystemVerification]: missing cgroups: memory
```
Changing it to the "cgroup_enable=memory" syntax and rebooting resolved that error.