### PR TITLE
Kernel 4.19.32 && Docker 18.09.3 et al.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,18 @@ ENV HYPRIOT_OS_VERSION=v1.2.6 \
 #artifacts remotely is enabled to validate downloaded remote artifacts
 ENV FETCH_MISSING_ARTIFACTS=true \
     ROOT_FS_ARTIFACT=rootfs-arm64-debian-$HYPRIOT_OS_VERSION.tar.gz \
-    KERNEL_ARTIFACT=4.14.37-hypriotos-v8.tar.gz \
+    KERNEL_ARTIFACT=4.19.32-hypriotos-v8.tar.gz \
     BOOTLOADER_ARTIFACT=rpi-bootloader.tar.gz \
     RAW_IMAGE_ARTIFACT=rpi-raw.img.zip \
-    DOCKER_ENGINE_VERSION="18.04.0~ce~3" \
-    DOCKER_COMPOSE_VERSION="1.21.1" \
-    DOCKER_MACHINE_VERSION="0.14.0" \
-    KERNEL_VERSION="4.14.37" \
+    CONTAINERD_IO_VERSION="1.2.4" \
+    DOCKER_ENGINE_VERSION="18.09.3~3" \
+    DOCKER_COMPOSE_VERSION="1.24.0" \
+    DOCKER_MACHINE_VERSION="0.16.1" \
+    KERNEL_VERSION="4.19.32" \
     ROOTFS_TAR_CHECKSUM="737c914f5d457772072cba8a647b31b564bcb2e896870e087f5ed6ccbcc9a1e9" \
     RAW_IMAGE_CHECKSUM="2fbeb13b7b0f2308dbd0d82780b54c33003ad43d145ff08498b25fb8bbe1c2c6" \
     BOOTLOADER_BUILD="20180320-071222" \
-    KERNEL_BUILD="20180429-164134"
+    KERNEL_BUILD="20190405-110847"
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Here I propose the updates to our builder pipeline using my earlier proposed 4.19.32 kernel package and fresher Docker packages. Everything tested locally including running on RPi 3B.