### PR TITLE
Switch to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+      - checkout
+
+      - run:
+          name: Run Shellcheck
+          command: |
+            make shellcheck
+
+      - run:
+          name: Create SD image
+          command: |
+            VERSION=${CIRCLE_TAG} make sd-image
+
+      - run:
+          name: Prepare artifacts
+          command: |
+            mkdir -p output
+            cp hypriotos*zip* output/
+
+      - store_artifacts:
+          path: /home/circleci/project/output
+
+      - deploy:
+          name: Deploy
+          command: |
+            if [ "$CIRCLE_TAG" != "" ]; then
+              curl -sSL https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip -o ghr.zip
+              unzip ghr.zip
+              if [[ $CIRCLE_TAG = *"rc"* ]]; then
+                pre=-prerelease
+              fi
+              ./ghr $pre -u hypriot $CIRCLE_TAG output/
+            fi
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ shell: build
 	VERSION=${VERSION} docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION -e GITHUB_OAUTH_TOKEN image-builder-rpi64 bash
 
 test:
-	VERSION=${VERSION} docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
+	VERSION=${VERSION} docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
 
 shellcheck: build
-	VERSION=${VERSION} docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi64 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
+	VERSION=${VERSION} docker run --rm -v $(shell pwd):/workspace koalaman/shellcheck:v0.7.0 /workspace/builder/build.sh /workspace/builder/chroot-script.sh /workspace/builder/files/etc/firstboot.d/10-resize-rootdisk
 
 vagrant:
 	vagrant up

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ shell: build
 test:
 	VERSION=${VERSION} docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e TRAVIS_TAG -e VERSION image-builder-rpi64 bash -c "unzip /workspace/hypriotos-rpi64-${VERSION}.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
 
-shellcheck: build
+shellcheck:
 	VERSION=${VERSION} docker run --rm -v $(shell pwd):/workspace koalaman/shellcheck:v0.7.0 /workspace/builder/build.sh /workspace/builder/chroot-script.sh /workspace/builder/files/etc/firstboot.d/10-resize-rootdisk
 
 vagrant:

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -102,11 +102,11 @@ umount -l ${BUILD_PATH}/sys
 
 # package image filesytem into two tarballs - one for bootfs and one for rootfs
 # ensure that there are no leftover artifacts in the pseudo filesystems
-rm -rf ${BUILD_PATH}/{dev,sys,proc}/*
+rm -rf ${BUILD_PATH:?}/{dev,sys,proc}/*
 
 tar -czf /image_with_kernel_boot.tar.gz -C ${BUILD_PATH}/boot .
 du -sh ${BUILD_PATH}/boot
-rm -Rf ${BUILD_PATH}/boot
+rm -Rf ${BUILD_PATH:?}/boot
 tar -czf /image_with_kernel_root.tar.gz -C ${BUILD_PATH} .
 du -sh ${BUILD_PATH}
 ls -alh /image_with_kernel_*.tar.gz


### PR DESCRIPTION
Let's switch from Travis to Circle.

What this PR does:

- Have artifacts per build / PR build stored in CircleCI, not as GitHub release, eg. https://circleci.com/gh/StefanScherer/image-builder-rpi64/3#artifacts/containers/0
- Enable shellcheck again
- Workflow for a release: Draft a GitHub release with a version number, CircleCI will trigger a fresh build and deploy it to GitHub.

Configuration of CircleCI
- Add project to CircleCI builds
- GITHUB_TOKEN secret is needed when a new (pre-)release should be deployed, but in the meantime we could just use the CircleCI artifacts to share the sd-card images while PR's are still open.
